### PR TITLE
[로또] 이동한 미션 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@
 
 ### exception
 - [x] IllegalArgument, IllegalState 커스텀에러 작성
+
+### view
+- [x] 출력 포맷을 위한 View 작성

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 ## 기능 구현
 
 ### Lotto (domain)
-- [ ] Lotto 도메인 생성시 검증
-- [ ] 당첨 결과 확인 기능
+- [x] Lotto 도메인 생성시 검증
+- [x] 당첨 결과 확인 기능
 
 ### LottoService (service)
-- [ ] 유저가 구입한 로또 전체 당첨기능 확인
+- [x] 유저가 구입한 로또 전체 당첨기능 확인
+
+### exception
+- [x] IllegalArgument, IllegalState 커스텀에러 작성

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # java-lotto-precourse
+
+## 기능 구현
+
+### Lotto (domain)
+- [ ] Lotto 도메인 생성시 검증
+- [ ] 당첨 결과 확인 기능
+
+### LottoService (service)
+- [ ] 유저가 구입한 로또 전체 당첨기능 확인

--- a/src/main/java/lotto/Application.java
+++ b/src/main/java/lotto/Application.java
@@ -1,7 +1,13 @@
 package lotto;
 
+import camp.nextstep.edu.missionutils.Console;
+
 public class Application {
     public static void main(String[] args) {
-        // TODO: 프로그램 구현
+        try {
+            LottoRunner.run();
+        } finally {
+            Console.close();
+        }
     }
 }

--- a/src/main/java/lotto/Lotto.java
+++ b/src/main/java/lotto/Lotto.java
@@ -1,6 +1,15 @@
 package lotto;
 
+import lotto.domain.LottoWinningTable;
+import lotto.exceptions.LottoNotUniqueException;
+import lotto.exceptions.LottoShortLengthException;
+
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
+import static lotto.utils.LottoValidator.*;
 
 public class Lotto {
     private final List<Integer> numbers;
@@ -12,9 +21,41 @@ public class Lotto {
 
     private void validate(List<Integer> numbers) {
         if (numbers.size() != 6) {
-            throw new IllegalArgumentException("[ERROR] 로또 번호는 6개여야 합니다.");
+            throw new LottoShortLengthException();
+        }
+        Set<Integer> uniqueNumbers = new HashSet<>(numbers);
+
+        if (uniqueNumbers.size() != numbers.size()) {
+            throw new LottoNotUniqueException();
         }
     }
 
-    // TODO: 추가 기능 구현
+    public LottoWinningTable getResult(final List<Integer> winningNumbers,final int bonusNumber) {
+
+        int matchCount = calculateMatchCount(winningNumbers);
+
+        if (matchCount < MINIMAL_WINNING_NUMBER) {
+            return null;
+        }
+
+        if (matchCount != BONUS_MATCH_INTERSECTION_NUMBER) {
+            return LottoWinningTable.findByMatchCount(matchCount);
+        }
+
+        if (numbers.contains(bonusNumber)) {
+            return LottoWinningTable.SECOND;
+        }
+
+        return LottoWinningTable.THIRD;
+    }
+
+    private int calculateMatchCount(final List<Integer> winningNumbers) {
+        return (int) winningNumbers.stream()
+                .filter(numbers::contains)
+                .count();
+    }
+
+    public List<Integer> getNumbers() {
+        return Collections.unmodifiableList(numbers);
+    }
 }

--- a/src/main/java/lotto/LottoRunner.java
+++ b/src/main/java/lotto/LottoRunner.java
@@ -1,4 +1,23 @@
 package lotto;
-public class LottoRunner {
 
+import lotto.domain.Lotto;
+import lotto.service.LottoService;
+import lotto.utils.LottoGenerator;
+import lotto.utils.UserInputUtil;
+import lotto.view.OutView;
+
+import java.util.List;
+
+public class LottoRunner {
+    public static void run() {
+        long purchaseBudget = UserInputUtil.takePurchaseBudget();
+        List<Lotto> userWallet = LottoGenerator.generateLottoWallet(purchaseBudget);
+
+        final LottoService lottoService = new LottoService(userWallet);
+        List<Integer> winningNumbers = UserInputUtil.takeLottoNumbers();
+        int bonusNumber = UserInputUtil.takeBonusNumber();
+        OutView.showWinningResult(
+                lottoService.getWinningResultTable(winningNumbers,bonusNumber)
+                ,purchaseBudget);
+    }
 }

--- a/src/main/java/lotto/LottoRunner.java
+++ b/src/main/java/lotto/LottoRunner.java
@@ -1,0 +1,4 @@
+package lotto;
+public class LottoRunner {
+
+}

--- a/src/main/java/lotto/LottoRunner.java
+++ b/src/main/java/lotto/LottoRunner.java
@@ -12,6 +12,7 @@ public class LottoRunner {
     public static void run() {
         long purchaseBudget = UserInputUtil.takePurchaseBudget();
         List<Lotto> userWallet = LottoGenerator.generateLottoWallet(purchaseBudget);
+        OutView.showWholeLottoInUserWallet(userWallet);
 
         final LottoService lottoService = new LottoService(userWallet);
         List<Integer> winningNumbers = UserInputUtil.takeLottoNumbers();

--- a/src/main/java/lotto/constants/ExceptionDisplayConstants.java
+++ b/src/main/java/lotto/constants/ExceptionDisplayConstants.java
@@ -1,0 +1,5 @@
+package lotto.constants;
+
+public class ExceptionDisplayConstants {
+    public static final String USER_INPUT_ERROR_PREFIX = "[ERROR]";
+}

--- a/src/main/java/lotto/constants/LottoConstants.java
+++ b/src/main/java/lotto/constants/LottoConstants.java
@@ -1,0 +1,5 @@
+package lotto.constants;
+
+public class LottoConstants {
+    public static final int LOTTO_PRICE_UNIT = 1000;
+}

--- a/src/main/java/lotto/constants/RegExConstants.java
+++ b/src/main/java/lotto/constants/RegExConstants.java
@@ -1,0 +1,14 @@
+package lotto.constants;
+
+public enum RegExConstants {
+    LOTTO_NUMBERS_REGEX("^(?:[1-9]|[1-3][0-9]|4[0-5])(,(?:[1-9]|[1-3][0-9]|4[0-5])){5}$");
+    private final String regex;
+
+    RegExConstants(String regex) {
+        this.regex = regex;
+    }
+
+    public String getRegex() {
+        return this.regex;
+    }
+}

--- a/src/main/java/lotto/domain/Lotto.java
+++ b/src/main/java/lotto/domain/Lotto.java
@@ -1,4 +1,4 @@
-package lotto;
+package lotto.domain;
 
 import lotto.domain.LottoWinningTable;
 import lotto.exceptions.LottoNotUniqueException;

--- a/src/main/java/lotto/domain/Lotto.java
+++ b/src/main/java/lotto/domain/Lotto.java
@@ -1,6 +1,5 @@
 package lotto.domain;
 
-import lotto.domain.LottoWinningTable;
 import lotto.exceptions.LottoNotUniqueException;
 import lotto.exceptions.LottoShortLengthException;
 

--- a/src/main/java/lotto/domain/LottoWinningTable.java
+++ b/src/main/java/lotto/domain/LottoWinningTable.java
@@ -43,6 +43,10 @@ public enum LottoWinningTable {
         return this.matchCount;
     }
 
+    public int getReward() {
+        return this.reward;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();

--- a/src/main/java/lotto/domain/LottoWinningTable.java
+++ b/src/main/java/lotto/domain/LottoWinningTable.java
@@ -1,0 +1,54 @@
+package lotto.domain;
+
+import lotto.exceptions.LottoInvalidMatchException;
+import org.junit.platform.commons.util.StringUtils;
+
+import static lotto.utils.LottoValidator.BONUS_MATCH_INTERSECTION_NUMBER;
+
+public enum LottoWinningTable {
+    FIFTH(3, 5_000),
+    FOURTH(4, 50_000),
+    THIRD(5, 1_500_000),
+    SECOND(5, 30_000_000, true),
+    FIRST(6, 2_000_000_000);
+    private final int matchCount;
+    private final int reward;
+    private final boolean hasBonus;
+
+    LottoWinningTable(int matchCount, int reward) {
+        this.matchCount = matchCount;
+        this.reward = reward;
+        this.hasBonus = false;
+    }
+
+    LottoWinningTable(int matchCount, int reward, boolean hasBonus) {
+        this.matchCount = matchCount;
+        this.reward = reward;
+        this.hasBonus = hasBonus;
+    }
+
+    public static LottoWinningTable findByMatchCount(int target) {
+        if (target == BONUS_MATCH_INTERSECTION_NUMBER) {
+            throw new LottoInvalidMatchException();
+        }
+        for (LottoWinningTable value : LottoWinningTable.values()) {
+            if (value.getMatchCount() == target) {
+                return value;
+            }
+        }
+        throw new LottoInvalidMatchException();
+    }
+
+    public int getMatchCount() {
+        return this.matchCount;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append(matchCount).append("개 일치");
+        if(hasBonus) sb.append(", 보너스 볼 일치");
+        sb.append(" (").append(String.format("%,d", reward)).append("원)");
+        return sb.toString();
+    }
+}

--- a/src/main/java/lotto/domain/LottoWinningTable.java
+++ b/src/main/java/lotto/domain/LottoWinningTable.java
@@ -1,7 +1,6 @@
 package lotto.domain;
 
 import lotto.exceptions.LottoInvalidMatchException;
-import org.junit.platform.commons.util.StringUtils;
 
 import static lotto.utils.LottoValidator.BONUS_MATCH_INTERSECTION_NUMBER;
 

--- a/src/main/java/lotto/exceptions/BonusNumberException.java
+++ b/src/main/java/lotto/exceptions/BonusNumberException.java
@@ -1,0 +1,11 @@
+package lotto.exceptions;
+
+import static lotto.constants.ExceptionDisplayConstants.USER_INPUT_ERROR_PREFIX;
+
+public class BonusNumberException extends IllegalArgumentException{
+    private static final String MESSAGE = USER_INPUT_ERROR_PREFIX + "보너스 번호는 1-45사이의 숫자 입니다.";
+
+    public BonusNumberException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/lotto/exceptions/LottoInvalidMatchException.java
+++ b/src/main/java/lotto/exceptions/LottoInvalidMatchException.java
@@ -1,0 +1,8 @@
+package lotto.exceptions;
+
+public class LottoInvalidMatchException extends IllegalStateException{
+    private static final String MESSAGE = "[ERROR] 로또 당첨횟수가 유효하지 않습니다.";
+    public LottoInvalidMatchException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/lotto/exceptions/LottoNotUniqueException.java
+++ b/src/main/java/lotto/exceptions/LottoNotUniqueException.java
@@ -1,0 +1,8 @@
+package lotto.exceptions;
+
+public class LottoNotUniqueException extends IllegalArgumentException{
+    private static final String MESSAGE = "[ERROR] 로또 번호는 중복되지 않아야합니다.";
+    public LottoNotUniqueException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/lotto/exceptions/LottoNumbersException.java
+++ b/src/main/java/lotto/exceptions/LottoNumbersException.java
@@ -1,0 +1,11 @@
+package lotto.exceptions;
+
+import static lotto.constants.ExceptionDisplayConstants.USER_INPUT_ERROR_PREFIX;
+
+public class LottoNumbersException extends IllegalArgumentException{
+    private static final String MESSAGE = USER_INPUT_ERROR_PREFIX + " 로또 번호는 1부터 45 사이의 6자리의 중복되지 않는 숫자여야 합니다.";
+
+    public LottoNumbersException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/lotto/exceptions/LottoShortLengthException.java
+++ b/src/main/java/lotto/exceptions/LottoShortLengthException.java
@@ -1,0 +1,8 @@
+package lotto.exceptions;
+
+public class LottoShortLengthException extends IllegalArgumentException{
+    private static final String MESSAGE = "[ERROR] 로또 번호는 6개여야 합니다.";
+    public LottoShortLengthException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/lotto/exceptions/PurchaseUnitException.java
+++ b/src/main/java/lotto/exceptions/PurchaseUnitException.java
@@ -1,0 +1,11 @@
+package lotto.exceptions;
+
+import static lotto.constants.ExceptionDisplayConstants.USER_INPUT_ERROR_PREFIX;
+
+public class PurchaseUnitException extends IllegalArgumentException{
+    private static final String MESSAGE = USER_INPUT_ERROR_PREFIX + " 구매금액은 1000으로 나누어 떨어지 양수여야 합니다.";
+
+    public PurchaseUnitException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/lotto/service/LottoService.java
+++ b/src/main/java/lotto/service/LottoService.java
@@ -1,7 +1,6 @@
 package lotto.service;
 
-import camp.nextstep.edu.missionutils.Randoms;
-import lotto.Lotto;
+import lotto.domain.Lotto;
 import lotto.domain.LottoWinningTable;
 
 import java.util.*;
@@ -13,7 +12,7 @@ public class LottoService {
         this.userLottoWallet = userLottoWallet;
     }
 
-    public Map<LottoWinningTable, Integer> getWinningResultTable(final List<Integer> winningNumbers, final int bonusNumber) {
+    public Map<LottoWinningTable, Integer> getWinningResultTable(final List<Integer> winningNumbers,int bonusNumber) {
         List<LottoWinningTable> validTable = filterValidWallet(winningNumbers, bonusNumber);
         Map<LottoWinningTable, Integer> result = new HashMap<>();
 

--- a/src/main/java/lotto/service/LottoService.java
+++ b/src/main/java/lotto/service/LottoService.java
@@ -1,0 +1,38 @@
+package lotto.service;
+
+import camp.nextstep.edu.missionutils.Randoms;
+import lotto.Lotto;
+import lotto.domain.LottoWinningTable;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class LottoService {
+    private final List<Lotto> userLottoWallet;
+    public LottoService(List<Lotto> userLottoWallet) {
+        this.userLottoWallet = userLottoWallet;
+    }
+
+    public Map<LottoWinningTable, Integer> getWinningResultTable(final List<Integer> winningNumbers, final int bonusNumber) {
+        List<LottoWinningTable> validTable = filterValidWallet(winningNumbers, bonusNumber);
+        Map<LottoWinningTable, Integer> result = new HashMap<>();
+
+        for (LottoWinningTable table : LottoWinningTable.values()) {
+            result.put(table, countMatchingNumberFromValidTable(validTable, table));
+        }
+        return result;
+    }
+
+    private int countMatchingNumberFromValidTable(final List<LottoWinningTable> validTable, LottoWinningTable target) {
+        return validTable.stream()
+                .filter(key -> key == target)
+                .mapToInt(key -> 1)
+                .sum();
+    }
+    private List<LottoWinningTable> filterValidWallet(final List<Integer> winningNumbers, final int bonusNumber ) {
+        return userLottoWallet.stream()
+                .map(lotto -> lotto.getResult(winningNumbers, bonusNumber))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/lotto/utils/LottoGenerator.java
+++ b/src/main/java/lotto/utils/LottoGenerator.java
@@ -1,16 +1,19 @@
 package lotto.utils;
 
 import camp.nextstep.edu.missionutils.Randoms;
-import lotto.Lotto;
+import lotto.domain.Lotto;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static lotto.constants.LottoConstants.LOTTO_PRICE_UNIT;
 
 public class LottoGenerator {
     private static final int LOTTO_RANGE_START = 1;
     private static final int LOTTO_RANGE_END = 45;
     private static final int LOTTO_NUMBER_LENGTH = 6;
-    public static List<Lotto> generateLottoWallet(int ea) {
+    public static List<Lotto> generateLottoWallet(long purchasePrice) {
+        int ea = (int) (purchasePrice / LOTTO_PRICE_UNIT);
         List<Lotto> wallet = new ArrayList<>();
         for (int i = 0; i < ea; i++) {
             List<Integer> lottoContent = Randoms.pickUniqueNumbersInRange(LOTTO_RANGE_START, LOTTO_RANGE_END, LOTTO_NUMBER_LENGTH)

--- a/src/main/java/lotto/utils/LottoGenerator.java
+++ b/src/main/java/lotto/utils/LottoGenerator.java
@@ -1,0 +1,24 @@
+package lotto.utils;
+
+import camp.nextstep.edu.missionutils.Randoms;
+import lotto.Lotto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LottoGenerator {
+    private static final int LOTTO_RANGE_START = 1;
+    private static final int LOTTO_RANGE_END = 45;
+    private static final int LOTTO_NUMBER_LENGTH = 6;
+    public static List<Lotto> generateLottoWallet(int ea) {
+        List<Lotto> wallet = new ArrayList<>();
+        for (int i = 0; i < ea; i++) {
+            List<Integer> lottoContent = Randoms.pickUniqueNumbersInRange(LOTTO_RANGE_START, LOTTO_RANGE_END, LOTTO_NUMBER_LENGTH)
+                    .stream()
+                    .sorted()
+                    .toList();
+            wallet.add(new Lotto(lottoContent));
+        }
+        return wallet;
+    }
+}

--- a/src/main/java/lotto/utils/LottoValidator.java
+++ b/src/main/java/lotto/utils/LottoValidator.java
@@ -1,0 +1,7 @@
+package lotto.utils;
+
+public class LottoValidator {
+    public static final int MINIMAL_WINNING_NUMBER = 3;
+    public static final int BONUS_MATCH_INTERSECTION_NUMBER = 5;
+    public static final int TOTAL_LOTTO_NUMBERS = 6;
+}

--- a/src/main/java/lotto/utils/LottoValidator.java
+++ b/src/main/java/lotto/utils/LottoValidator.java
@@ -3,5 +3,4 @@ package lotto.utils;
 public class LottoValidator {
     public static final int MINIMAL_WINNING_NUMBER = 3;
     public static final int BONUS_MATCH_INTERSECTION_NUMBER = 5;
-    public static final int TOTAL_LOTTO_NUMBERS = 6;
 }

--- a/src/main/java/lotto/utils/UserInputUtil.java
+++ b/src/main/java/lotto/utils/UserInputUtil.java
@@ -1,6 +1,8 @@
 package lotto.utils;
 
+import lotto.constants.LottoConstants;
 import lotto.constants.RegExConstants;
+import lotto.exceptions.BonusNumberException;
 import lotto.exceptions.LottoNumbersException;
 import lotto.exceptions.PurchaseUnitException;
 
@@ -15,32 +17,53 @@ import static camp.nextstep.edu.missionutils.Console.readLine;
 public class UserInputUtil {
     private static final String PURCHASE_REQUEST_MESSAGE = "구입금액을 입력해 주세요.";
     private static final String LOTTO_NUMBERS_REQUEST_MESSAGE = "당첨 번호를 입력해 주세요.";
+    private static final String LOTTO_BONUS_REQUEST_MESSAGE = "보너스 번호를 입력해 주세요.";
     private static final String LOTTO_NUMBERS_DELIMITER = ",";
     private static final int LOTTO_NUMBERS_SIZE = 6;
+
+    public static int takeBonusNumber() {
+        try {
+            System.out.println(LOTTO_BONUS_REQUEST_MESSAGE);
+            final String rawBonusInput = readLine();
+            return validateBonusNumber(rawBonusInput);
+        } catch (BonusNumberException e) {
+            return takeBonusNumber();
+        }
+    }
     public static long takePurchaseBudget() {
-        while (true) {
-            try {
-                System.out.println(PURCHASE_REQUEST_MESSAGE);
-                final String rawPurchaseAmount = readLine();
-                return validatePurchaseAmount(rawPurchaseAmount);
-            } catch (PurchaseUnitException e) {
-                System.out.println(e.getMessage());
-            }
+        try {
+            System.out.println(PURCHASE_REQUEST_MESSAGE);
+            final String rawPurchaseAmount = readLine();
+            return validatePurchaseAmount(rawPurchaseAmount);
+        } catch (PurchaseUnitException e) {
+            return takePurchaseBudget();
         }
     }
 
     public static List<Integer> takeLottoNumbers() {
-        while (true) {
-            try {
-                System.out.println(LOTTO_NUMBERS_REQUEST_MESSAGE);
-                final String rawPurchaseAmount = readLine();
-                return validateLottoNumbers(rawPurchaseAmount);
-            } catch (LottoNumbersException e) {
-                System.out.println(e.getMessage());
-            }
+        try {
+            System.out.println(LOTTO_NUMBERS_REQUEST_MESSAGE);
+            final String rawPurchaseAmount = readLine();
+            return validateLottoNumbers(rawPurchaseAmount);
+        } catch (LottoNumbersException e) {
+            return takeLottoNumbers();
         }
     }
 
+    private static int validateBonusNumber(final String rawInput) {
+        int result;
+
+        try {
+            result = Integer.parseInt(rawInput);
+        } catch (NumberFormatException e) {
+            throw new BonusNumberException();
+        }
+        if (result > 0 && result < 46) {
+            return result;
+        }
+
+        throw new BonusNumberException();
+    }
     private static List<Integer> validateLottoNumbers(final String rawInput) {
         Matcher matcher = Pattern.compile(RegExConstants.LOTTO_NUMBERS_REGEX.getRegex())
                 .matcher(rawInput);
@@ -66,7 +89,7 @@ public class UserInputUtil {
             throw new PurchaseUnitException();
         }
 
-        if (parsedPurchaseAmount % 1000 != 0 || parsedPurchaseAmount < 0) {
+        if (parsedPurchaseAmount % LottoConstants.LOTTO_PRICE_UNIT != 0 || parsedPurchaseAmount < 0) {
             throw new PurchaseUnitException();
         }
         return parsedPurchaseAmount;

--- a/src/main/java/lotto/utils/UserInputUtil.java
+++ b/src/main/java/lotto/utils/UserInputUtil.java
@@ -1,0 +1,74 @@
+package lotto.utils;
+
+import lotto.constants.RegExConstants;
+import lotto.exceptions.LottoNumbersException;
+import lotto.exceptions.PurchaseUnitException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static camp.nextstep.edu.missionutils.Console.readLine;
+
+public class UserInputUtil {
+    private static final String PURCHASE_REQUEST_MESSAGE = "구입금액을 입력해 주세요.";
+    private static final String LOTTO_NUMBERS_REQUEST_MESSAGE = "당첨 번호를 입력해 주세요.";
+    private static final String LOTTO_NUMBERS_DELIMITER = ",";
+    private static final int LOTTO_NUMBERS_SIZE = 6;
+    public static long takePurchaseBudget() {
+        while (true) {
+            try {
+                System.out.println(PURCHASE_REQUEST_MESSAGE);
+                final String rawPurchaseAmount = readLine();
+                return validatePurchaseAmount(rawPurchaseAmount);
+            } catch (PurchaseUnitException e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    public static List<Integer> takeLottoNumbers() {
+        while (true) {
+            try {
+                System.out.println(LOTTO_NUMBERS_REQUEST_MESSAGE);
+                final String rawPurchaseAmount = readLine();
+                return validateLottoNumbers(rawPurchaseAmount);
+            } catch (LottoNumbersException e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    private static List<Integer> validateLottoNumbers(final String rawInput) {
+        Matcher matcher = Pattern.compile(RegExConstants.LOTTO_NUMBERS_REGEX.getRegex())
+                .matcher(rawInput);
+        if (!matcher.matches()) {
+            throw new LottoNumbersException();
+        }
+        List<Integer> numbers = Arrays.stream(rawInput.split(LOTTO_NUMBERS_DELIMITER))
+                .map(Integer::parseInt)
+                .distinct()
+                .collect(Collectors.toList());
+        if (numbers.size() != LOTTO_NUMBERS_SIZE) {
+            throw new LottoNumbersException();
+        }
+        return numbers;
+    }
+
+    private static long validatePurchaseAmount(final String rawInput) {
+        long parsedPurchaseAmount;
+
+        try {
+            parsedPurchaseAmount = Long.parseLong(rawInput);
+        } catch (NumberFormatException e) {
+            throw new PurchaseUnitException();
+        }
+
+        if (parsedPurchaseAmount % 1000 != 0 || parsedPurchaseAmount < 0) {
+            throw new PurchaseUnitException();
+        }
+        return parsedPurchaseAmount;
+    }
+}

--- a/src/main/java/lotto/utils/UserInputUtil.java
+++ b/src/main/java/lotto/utils/UserInputUtil.java
@@ -25,8 +25,11 @@ public class UserInputUtil {
         try {
             System.out.println(LOTTO_BONUS_REQUEST_MESSAGE);
             final String rawBonusInput = readLine();
+            System.out.println();
             return validateBonusNumber(rawBonusInput);
         } catch (BonusNumberException e) {
+            System.out.println(e.getMessage());
+            System.out.println();
             return takeBonusNumber();
         }
     }
@@ -34,8 +37,11 @@ public class UserInputUtil {
         try {
             System.out.println(PURCHASE_REQUEST_MESSAGE);
             final String rawPurchaseAmount = readLine();
+            System.out.println();
             return validatePurchaseAmount(rawPurchaseAmount);
         } catch (PurchaseUnitException e) {
+            System.out.println(e.getMessage());
+            System.out.println();
             return takePurchaseBudget();
         }
     }
@@ -44,8 +50,11 @@ public class UserInputUtil {
         try {
             System.out.println(LOTTO_NUMBERS_REQUEST_MESSAGE);
             final String rawPurchaseAmount = readLine();
+            System.out.println();
             return validateLottoNumbers(rawPurchaseAmount);
         } catch (LottoNumbersException e) {
+            System.out.println(e.getMessage());
+            System.out.println();
             return takeLottoNumbers();
         }
     }

--- a/src/main/java/lotto/view/OutView.java
+++ b/src/main/java/lotto/view/OutView.java
@@ -1,0 +1,30 @@
+package lotto.view;
+
+import lotto.domain.LottoWinningTable;
+
+import java.util.Map;
+import java.util.Set;
+
+public class OutView {
+    public static final String RESULT_DISPLAY_FORMAT = "%s - %d개\n";
+    private static final String PROFIT_PRINT_FORMAT = "총 수익률은 %.1f%%입니다.\n";
+    public static void showWinningResult(final Map<LottoWinningTable, Integer> winningResultTable,final long purchasePrice) {
+        Set<Map.Entry<LottoWinningTable, Integer>> entries = winningResultTable.entrySet();
+        for (LottoWinningTable table : LottoWinningTable.values()) {
+            System.out.printf(RESULT_DISPLAY_FORMAT, table.toString(), winningResultTable.get(table));
+        }
+        System.out.printf(PROFIT_PRINT_FORMAT, turnIntoPercent((float) calculateProfit(entries)/ purchasePrice));
+    }
+    private static long calculateProfit(final Set<Map.Entry<LottoWinningTable, Integer>> entries) {
+        long result = 0;
+        for (Map.Entry<LottoWinningTable, Integer> entry : entries) {
+            long diff = (long) entry.getKey().getReward() * entry.getValue();
+            result += diff;
+        }
+        return result;
+    }
+
+    private static double turnIntoPercent(double profitRatio) {
+        return Math.round(profitRatio * 1000) / 10.0;
+    }
+}

--- a/src/main/java/lotto/view/OutView.java
+++ b/src/main/java/lotto/view/OutView.java
@@ -1,14 +1,28 @@
 package lotto.view;
 
+import lotto.domain.Lotto;
 import lotto.domain.LottoWinningTable;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public class OutView {
-    public static final String RESULT_DISPLAY_FORMAT = "%s - %d개\n";
+    private static final String NUMBER_OF_PURCHASED_LOTTO_DISPLAY_FORMAT = "%d개를 구매했습니다.\n";
+    private static final String RESULT_TITLE_FORMAT = "당첨 통계\n---";
+    private static final String RESULT_DISPLAY_FORMAT = "%s - %d개\n";
     private static final String PROFIT_PRINT_FORMAT = "총 수익률은 %.1f%%입니다.\n";
+
+    public static void showWholeLottoInUserWallet(final List<Lotto> userWallet) {
+        System.out.printf(NUMBER_OF_PURCHASED_LOTTO_DISPLAY_FORMAT, userWallet.size());
+        for (Lotto userLotto :
+                userWallet) {
+            System.out.println(userLotto.getNumbers());
+        }
+        System.out.println();
+    }
     public static void showWinningResult(final Map<LottoWinningTable, Integer> winningResultTable,final long purchasePrice) {
+        System.out.println(RESULT_TITLE_FORMAT);
         Set<Map.Entry<LottoWinningTable, Integer>> entries = winningResultTable.entrySet();
         for (LottoWinningTable table : LottoWinningTable.values()) {
             System.out.printf(RESULT_DISPLAY_FORMAT, table.toString(), winningResultTable.get(table));

--- a/src/test/java/lotto/ApplicationTest.java
+++ b/src/test/java/lotto/ApplicationTest.java
@@ -54,6 +54,14 @@ class ApplicationTest extends NsTest {
         });
     }
 
+    @Test
+    void 구입요금이_1000으로_나누어떨어지지_않으면_에러발생() {
+        assertSimpleTest(()->{
+            runException("750");
+            assertThat(output()).contains(ERROR_MESSAGE);
+        });
+    }
+
     @Override
     public void runMain() {
         Application.main(new String[]{});

--- a/src/test/java/lotto/LottoTest.java
+++ b/src/test/java/lotto/LottoTest.java
@@ -1,5 +1,6 @@
 package lotto;
 
+import lotto.domain.Lotto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/lotto/LottoTest.java
+++ b/src/test/java/lotto/LottoTest.java
@@ -23,4 +23,12 @@ class LottoTest {
     }
 
     // TODO: 추가 기능 구현에 따른 테스트 코드 작성
+    @Test
+    void Lotto_불변이다() {
+        Lotto lotto = new Lotto(List.of(1, 2, 3, 4, 5, 6));
+        List<Integer> numbers = lotto.getNumbers();
+        assertThatThrownBy(() -> {
+            numbers.add(2);
+        }).isInstanceOf(UnsupportedOperationException.class);
+    }
 }

--- a/src/test/java/lotto/service/LottoServiceTest.java
+++ b/src/test/java/lotto/service/LottoServiceTest.java
@@ -1,7 +1,0 @@
-package lotto.service;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-class LottoServiceTest {
-
-}

--- a/src/test/java/lotto/service/LottoServiceTest.java
+++ b/src/test/java/lotto/service/LottoServiceTest.java
@@ -1,0 +1,7 @@
+package lotto.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LottoServiceTest {
+
+}


### PR DESCRIPTION
## 기능 요구 사항
간단한 로또 발매기를 구현한다.

- 로또 번호의 숫자 범위는 1~45까지이다.
- 1개의 로또를 발행할 때 중복되지 않는 6개의 숫자를 뽑는다.
- 당첨 번호 추첨 시 중복되지 않는 숫자 6개와 보너스 번호 1개를 뽑는다.
- 당첨은 1등부터 5등까지 있다. 당첨 기준과 금액은 아래와 같다.
   - 1등: 6개 번호 일치 / 2,000,000,000원
   - 2등: 5개 번호 + 보너스 번호 일치 / 30,000,000원
   - 3등: 5개 번호 일치 / 1,500,000원
   - 4등: 4개 번호 일치 / 50,000원
   - 5등: 3개 번호 일치 / 5,000원
- 로또 구입 금액을 입력하면 구입 금액에 해당하는 만큼 로또를 발행해야 한다.
- 로또 1장의 가격은 1,000원이다.
- 당첨 번호와 보너스 번호를 입력받는다.
- 사용자가 구매한 로또 번호와 당첨 번호를 비교하여 당첨 내역 및 수익률을 출력하고 로또 게임을 종료한다.
- 사용자가 잘못된 값을 입력할 경우 IllegalArgumentException을 발생시키고, "[ERROR]"로 시작하는 에러 메시지를 출력 후 그 부분부터 입력을 다시 받는다.
 - Exception이 아닌 IllegalArgumentException, IllegalStateException 등과 같은 명확한 유형을 처리한다.

## 기능 구현

### Lotto (domain)
- [x] Lotto 도메인 생성시 검증
- [x] 당첨 결과 확인 기능

### LottoService (service)
- [x] 유저가 구입한 로또 전체 당첨기능 확인

### exception
- [x] IllegalArgument, IllegalState 커스텀에러 작성

### view
- [x] 출력 포맷을 위한 View 작성

## 입출력 요구 사항
### 입력
 - 로또 구입 금액을 입력 받는다. 구입 금액은 1,000원 단위로 입력 받으며 1,000원으로 나누어 떨어지지 않는 경우 예외 처리한다.
 - 당첨 번호를 입력 받는다. 번호는 쉼표(,)를 기준으로 구분한다.
 - 보너스 번호를 입력 받는다.

### 출력
 - 발행한 로또 수량 및 번호를 출력한다. 로또 번호는 오름차순으로 정렬하여 보여준다.
 - 당첨 내역을 출력한다.
 - 수익률은 소수점 둘째 자리에서 반올림한다.
 - 예외 상황 시 에러 문구를 출력해야 한다. 단, 에러 문구는 "[ERROR]"로 시작해야 한다.

## 실행 결과 예시
```
구입금액을 입력해 주세요.
8000

8개를 구매했습니다.
[8, 21, 23, 41, 42, 43] 
[3, 5, 11, 16, 32, 38] 
[7, 11, 16, 35, 36, 44] 
[1, 8, 11, 31, 41, 42] 
[13, 14, 16, 38, 42, 45] 
[7, 11, 30, 40, 42, 43] 
[2, 13, 22, 32, 38, 45] 
[1, 3, 5, 14, 22, 45]

당첨 번호를 입력해 주세요.
1,2,3,4,5,6

보너스 번호를 입력해 주세요.
7

당첨 통계
---
3개 일치 (5,000원) - 1개
4개 일치 (50,000원) - 0개
5개 일치 (1,500,000원) - 0개
5개 일치, 보너스 볼 일치 (30,000,000원) - 0개
6개 일치 (2,000,000,000원) - 0개
총 수익률은 62.5%입니다.
```